### PR TITLE
Display errors as code blocks

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,11 +40,11 @@ fn main() {
    {#if errorState}
     <Modal open={true} on:close={() => (errorState = null)}>
       <h2>Error</h2>
-      <p>{errorState}</p>
+      <pre>
+        <code>{errorState}</code>
+      </pre>
     </Modal>
   {/if}
-
-
   
   <div class="layout">
     <Panel>

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -14,6 +14,7 @@ export class Client {
             err.code = resp.error.code;
             err.data = resp.error.data;
             err.message = resp.error.message;
+            err.method = method;
             throw err;
         }
 
@@ -55,9 +56,10 @@ class ApiError {
     code: number = 0;
     data: string = "";
     message: string = "";
+    method: string = "";
 
     public toString(): string {
-        return `${this.message} (Code ${this.code}):\n${this.data}`;
+        return `${this.message} (Code ${this.code}) while calling ${this.method}:\n${this.data}`;
     }
 }
 


### PR DESCRIPTION
Errors can contain backtraces that are easier to read inside code blocks.